### PR TITLE
Allow extraction of long path names.

### DIFF
--- a/libmspack4n/MSCompressedFile.cs
+++ b/libmspack4n/MSCompressedFile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace LibMSPackN
 {
@@ -64,33 +65,66 @@ namespace LibMSPackN
 		{
 			ThrowOnInvalidState();
 			IntPtr pDestinationFilename = IntPtr.Zero;
+			string longDestinationFilename = longFilename(destinationFilename);
 			try
 			{
-				pDestinationFilename = Marshal.StringToCoTaskMemAnsi(destinationFilename);
+				pDestinationFilename = Marshal.StringToCoTaskMemAnsi(longDestinationFilename);
 				var result = NativeMethods.mspack_invoke_mscab_decompressor_extract(_parentCabinet.Decompressor, _pNativeFile, pDestinationFilename);
 				if (result != NativeMethods.MSPACK_ERR.MSPACK_ERR_OK)
-					throw new Exception(string.Format("Error '{0}' extracting file to {1}.", result, destinationFilename));
-				
-				var modifiedTime = GetModifiedTime();
-				File.SetCreationTime(destinationFilename, modifiedTime);
-				File.SetLastWriteTime(destinationFilename, modifiedTime);
+					throw new Exception(string.Format("Error '{0}' extracting file to {1}.", result, longDestinationFilename));
 
-				var theAttributes = File.GetAttributes(destinationFilename);
+				// Long-form filenames are not supported by the .NET system libraries,
+				// so we must do win32 calls to set file time-stamps and attributes.
+				SafeFileHandle h = NativeMethods.CreateFile(
+					longDestinationFilename,
+					NativeMethods.FileAccess.FILE_READ_ATTRIBUTES | NativeMethods.FileAccess.FILE_WRITE_ATTRIBUTES,
+					NativeMethods.FileShare.FILE_SHARE_READ | NativeMethods.FileShare.FILE_SHARE_WRITE | NativeMethods.FileShare.FILE_SHARE_DELETE,
+					IntPtr.Zero,
+					NativeMethods.CreationDisposition.OPEN_EXISTING,
+					NativeMethods.FileAttributes.FILE_ATTRIBUTE_NORMAL | NativeMethods.FileAttributes.FILE_FLAG_BACKUP_SEMANTICS,
+					IntPtr.Zero);
+				if (h.IsInvalid)
+					throw new Exception(string.Format("Error {0} opening {1}.", Marshal.GetLastWin32Error(), longDestinationFilename));
+				using (h)
+				{
+					var modifiedTime = GetModifiedTime().ToFileTime();
+					if (!NativeMethods.SetFileTime(
+							h.DangerousGetHandle(),
+							ref modifiedTime, IntPtr.Zero, ref modifiedTime))
+						throw new Exception(string.Format("Error {0} setting times for {1}.", Marshal.GetLastWin32Error(), longDestinationFilename));
+				}
+				var theAttributes = NativeMethods.GetFileAttributes(longDestinationFilename);
+				if (theAttributes == (uint)NativeMethods.FileAttributes.INVALID_FILE_ATTRIBUTES)
+					throw new Exception(string.Format("Error {0} getting attributes of {1}.", Marshal.GetLastWin32Error(), longDestinationFilename));
+	
 				if ((_nativeFile.attribs & NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_ARCH) == NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_ARCH)
-					theAttributes |= FileAttributes.Archive;
+					theAttributes |= (uint)FileAttributes.Archive;
 				if ((_nativeFile.attribs & NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_HIDDEN) == NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_HIDDEN)
-					theAttributes |= FileAttributes.Hidden;
+					theAttributes |= (uint)FileAttributes.Hidden;
 				if ((_nativeFile.attribs & NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_RDONLY) == NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_RDONLY)
-					theAttributes |= FileAttributes.ReadOnly;
+					theAttributes |= (uint)FileAttributes.ReadOnly;
 				if ((_nativeFile.attribs & NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_SYSTEM) == NativeMethods.mscabd_file_attribs.MSCAB_ATTRIB_SYSTEM)
-					theAttributes |= FileAttributes.System;
-				File.SetAttributes(destinationFilename, theAttributes);
+					theAttributes |= (uint)FileAttributes.System;
+				if (!NativeMethods.SetFileAttributes(longDestinationFilename, theAttributes))
+					throw new Exception(string.Format("Error {0} setting attributes of {1}.", Marshal.GetLastWin32Error(), longDestinationFilename));
 			}
 			finally
 			{
 				if (pDestinationFilename != IntPtr.Zero)
 					Marshal.FreeCoTaskMem(pDestinationFilename);
 			}
+		}
+
+		// Convert a filename (assumed to be absolute) to the "extended" form
+		// that permits it to be longer than 260 characters.
+		private string longFilename(string filename)
+		{
+			if (filename.StartsWith("\\\\?\\"))
+				return filename;		// Already on long form.
+			else if (filename.StartsWith("\\\\"))
+				return "\\\\?\\UNC\\" + filename.Substring(2);
+			else
+				return "\\\\?\\" + filename;
 		}
 
 		private DateTime GetModifiedTime()

--- a/libmspack4n/NativeMethods.cs
+++ b/libmspack4n/NativeMethods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace LibMSPackN
 {
@@ -389,5 +390,53 @@ namespace LibMSPackN
 
 		// ReSharper restore EnumUnderlyingTypeIsInt
 		// ReSharper restore InconsistentNaming
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		internal static extern SafeFileHandle CreateFile(
+			string lpFileName, FileAccess dwDesiredAccess,
+			FileShare dwShareMode, IntPtr lpSecurityAttributes,
+			CreationDisposition dwCreationDisposition,
+			FileAttributes dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+		internal enum FileAccess : uint
+		{
+			FILE_READ_ATTRIBUTES = 0x80,
+			FILE_WRITE_ATTRIBUTES = 0x100,
+		}
+
+		internal enum FileShare : uint
+		{
+			FILE_SHARE_READ = 1,
+			FILE_SHARE_WRITE = 2,
+			FILE_SHARE_DELETE = 4,
+		}
+
+		internal enum CreationDisposition : uint
+		{
+			OPEN_EXISTING = 3,
+		}
+
+		internal enum FileAttributes : uint
+		{
+			FILE_ATTRIBUTE_NORMAL = 0x80,
+			FILE_FLAG_BACKUP_SEMANTICS = 0x02000000,
+			INVALID_FILE_ATTRIBUTES = 0xffffffff,
+		}
+	
+		// This binding only allows setting creation and last write times.
+		// The last access time parameter must be zero; that time is not
+		// modified.
+		[DllImport("kernel32.dll", SetLastError = true)]
+		internal static extern bool SetFileTime(
+			IntPtr hFile,
+			ref long lpCreationTime,
+			IntPtr lpLastAccessTime,
+			ref long lpLastWriteTime);
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		internal static extern uint GetFileAttributes(string lpFileName);
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		internal static extern bool SetFileAttributes(string lpFileName, uint dwFileAttributes);
 	}
 }


### PR DESCRIPTION
Use the extended path name syntax when extracting files, so that files
can be extracted even when the resulting file name exceeds the
standard Windows 260 character limit.

The .NET libraries do not permit the use of extended path names, so
some operations (setting the file time-stamps and attributes) have to
be done by Win32 calls.